### PR TITLE
[WIP] Add documentation on read the docs

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -1,0 +1,17 @@
+Once `docker-php` is installed through composer you can start using it:
+
+## Connecting
+
+By default, Docker-PHP does not make any asumption on where your docker daemon is, you will need to specify the entrypoint when creating the client.
+
+By default, Docker-PHP uses the `DOCKER_HOST` environment variable to connect to a running `dockerd`, if not set it will use `unix:///var/run/docker.sock`.
+You can, however, connect to an arbitrary server by passing an instance of the transport entrypoint `Docker\Http\Client`:
+
+```php
+<?php
+
+$client = new Docker\Http\DockerClient(array(), 'tcp://127.0.0.1');
+$docker = new Docker\Docker($client);
+```
+
+`DockerClient` is in fact a Guzzle Client with some default options.

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,29 +1,4 @@
-# Docker-PHP
-
-* [Connecting to Docker](#connecting-to-docker)
-* [Running a container](#running-a-container)
- * [Streaming a running container's output](#streaming-a-running-containers-output)
- * [Running a container as a daemon](#running-a-container-as-a-daemon)
-* [Creating, starting, attaching and waiting for containers](#creating-starting-attaching-and-waiting-for-containers)
-* [Mapping a container's ports](#mapping-a-containers-ports)
-* [Finding and inspecting Containers](#finding-and-inspecting-containers)
-* [Stopping and removing containers](#stopping-and-removing-containers)
-* [The Docker\Container class](#the-dockercontainer-class)
- * [Configuring exposed ports](#configuring-exposed-ports)
-
-## Connecting to Docker
-
-By default, Docker-PHP uses the `DOCKER_HOST` environment variable to connect to a running `dockerd`, if not set it will use `unix:///var/run/docker.sock`.
-You can, however, connect to an arbitrary server by passing an instance of the transport entrypoint `Docker\Http\Client`:
-
-```php
-<?php
-
-$client = new Docker\Http\DockerClient(array(), 'tcp://127.0.0.1');
-$docker = new Docker\Docker($client);
-```
-
-`DockerClient` is in fact a Guzzle Client with some default options.
+# Dealing with containers
 
 ## Running a container
 

--- a/docs/image/find.md
+++ b/docs/image/find.md
@@ -1,0 +1,1 @@
+# Create an image

--- a/docs/image/pull.md
+++ b/docs/image/pull.md
@@ -1,0 +1,2 @@
+# Pull an image
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Docker-PHP
+
+This is the documentation for [docker-php](https://github.com/stage1/docker-php) library. 
+
+* [Connecting to Docker](#connecting-to-docker)
+* [Running a container](#running-a-container)
+ * [Streaming a running container's output](#streaming-a-running-containers-output)
+ * [Running a container as a daemon](#running-a-container-as-a-daemon)
+* [Creating, starting, attaching and waiting for containers](#creating-starting-attaching-and-waiting-for-containers)
+* [Mapping a container's ports](#mapping-a-containers-ports)
+* [Finding and inspecting Containers](#finding-and-inspecting-containers)
+* [Stopping and removing containers](#stopping-and-removing-containers)
+* [The Docker\Container class](#the-dockercontainer-class)
+ * [Configuring exposed ports](#configuring-exposed-ports)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,13 @@
+# Installation
+
+The recommended way to install Docker PHP is of course to use [Composer](http://getcomposer.org/):
+
+```json
+{
+    "require": {
+        "stage1/docker-php": "@dev"
+    }
+}
+```
+
+**Note**: there is no stable version of Docker PHP yet.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: Docker PHP
+site_url:  http://docker-php.readthedocs.org/
+site_description: A Docker client in PHP
+repo_url: https://github.com/stage1/docker-php
+
+pages:
+  - [index.md, Home]
+  - [installation.md, 'Docker PHP', Installation]
+  - [basic.md, 'Docker PHP', Basic Usage]
+  - [image/build.md, Images, Build an image]
+  - [image/pull.md, Images, Pulling an image]
+  - [image/find.md, Images, Find an image]
+  - [container.md, Containers]


### PR DESCRIPTION
Work in progress on the documentation:

* Use readthedocs (for versioning purpose)
* Separate Container / Image concept
* Add some cookbooks on how to do A ?, how to do B ? ....

This branch is currently building at: http://docker-php.readthedocs.org/en/feature-readthedocs (manual trigger for the moment)

ping @ubermuda :)