### PR TITLE
ImageManager::inspect(), use id not repo:tag to identify. 

### DIFF
--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -98,7 +98,7 @@ class ContainerManager
      * @throws \GuzzleHttp\Exception\RequestException
      * @throws \Docker\Exception\ContainerNotFoundException
      *
-     * @return ContainerManager
+     * @return return json data from docker inspect
      */
     public function inspect(Container $container)
     {

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -109,12 +109,12 @@ class ImageManager
     public function inspect(Image $image)
     {
         try {
-            # Prefer the unique hash id for searching
-            if (null != $image->getID()) {
-              $id=$image->getID();
-            }
-            else {
-              $id=$image->__toString();
+            # Images need not have a name and tag,(__toString() may return ':')
+            # so prefer an id hash as the key
+            if (null != $image->getId()) {
+              $id = $image->getId();
+            } else {
+              $id = $image->__toString();
             }
             $response = $this->client->get(['/images/{id}/json', ['id' => $id]]);
         } catch (RequestException $e) {

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -109,10 +109,17 @@ class ImageManager
     public function inspect(Image $image)
     {
         try {
-            $response = $this->client->get(['/images/{id}/json', ['id' => $image->getID()]]);
+            # Prefer the unique hash id for searching
+            if (null != $image->getID()) {
+              $id=$image->getID();
+            }
+            else {
+              $id=$image->__toString();
+            }
+            $response = $this->client->get(['/images/{id}/json', ['id' => $id]]);
         } catch (RequestException $e) {
             if ($e->hasResponse() && $e->getResponse()->getStatusCode() == "404") {
-                throw new ImageNotFoundException('repo:tag=' . $image->__toString() . 'id=' . $image->getID(), $e);
+                throw new ImageNotFoundException($id, $e);
             }
 
             throw $e;

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -104,15 +104,15 @@ class ImageManager
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      * @throws \GuzzleHttp\Exception\RequestException
      *
-     * @return ImageManager
+     * @return @return json data from docker inspect
      */
     public function inspect(Image $image)
     {
         try {
-            $response = $this->client->get(['/images/{id}/json', ['id' => $image->__toString()]]);
+            $response = $this->client->get(['/images/{id}/json', ['id' => $image->getID()]]);
         } catch (RequestException $e) {
             if ($e->hasResponse() && $e->getResponse()->getStatusCode() == "404") {
-                throw new ImageNotFoundException($image->__toString(), $e);
+                throw new ImageNotFoundException('repo:tag=' . $image->__toString() . 'id=' . $image->getID(), $e);
             }
 
             throw $e;

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -104,7 +104,7 @@ class ImageManager
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      * @throws \GuzzleHttp\Exception\RequestException
      *
-     * @return @return json data from docker inspect
+     * @return json data from docker inspect
      */
     public function inspect(Image $image)
     {

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -117,7 +117,9 @@ class ImageManager
             } else {
               $id = $image->__toString();
             }
+
             $response = $this->client->get(['/images/{id}/json', ['id' => $id]]);
+
         } catch (RequestException $e) {
             if ($e->hasResponse() && $e->getResponse()->getStatusCode() == "404") {
                 throw new ImageNotFoundException($id, $e);

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -90,7 +90,8 @@ class ImageManager
     {
         $image = new Image($repository, $tag);
 
-        $this->inspect($image);
+        $data = $this->inspect($image);
+        $image->setId($data['Id']);
 
         return $image;
     }
@@ -129,12 +130,7 @@ class ImageManager
             throw UnexpectedStatusCodeException::fromResponse($response);
         }
 
-        $data = $response->json();
-
-        $image->setId($data['Id']);
-        // @TODO Add extra info on image
-
-        return $data;
+        return $response->json();
     }
 
     /**


### PR DESCRIPTION
Images need not have a name and tag, so __toString(9 may return "<none>:<none>"
hence one needs to the the id (e.g. 5a6ad7a9472d661def485ec19146a69f7ae1a78d3064c9d0cc18b44fe445f279).

I came across this when trying to list all images as follows. the inspect() line will not work without this fix.
$images = $imagemgr->findAll();
foreach ($images as $image) {
  $data=$imagemgr->inspect($image);
  print($image->__toString() . " " . $data['Created'] . " " . $image->getID() . "\n");
}

Also: 
- Improved error string. Doc: correct return.

Could we briefly talk about these two lines, before finalising the commit? See #78 
        $image->setId($data['Id']);
        // @TODO Add extra info on image
