### PR TITLE
Add removeContainers to ContainerManager

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -35,6 +35,7 @@ You can run a container as a daemon (effectively making the `run()` method non-b
 
 $manager->run($container, $callback, [], true);
 ```
+
 ## Creating, starting, attaching and waiting for containers
 
 The `run()` command is actually a composite of `create()`, `start()`, `attach` and `wait`, just like the `docker run` CLI command that you might be used to. You can use these methods to gain more fine-grained control over your containers' workflow.
@@ -150,6 +151,27 @@ $manager
     ->remove($container);
 ```
 
+The `remove` method has a second argument (defaults to `false`) `$volumes` which allows you to remove the volumes associated with the container by setting it to `true`.
+
+
+```php
+$manager->remove($container, true);
+```
+
+
+## Removing multiple containers
+
+You can remove multiple containers at once by passing an array of `Docker\Container` instances or strings (container id or container name) to the `removeContainers()` method.
+
+```php
+$manager->removeContainers([$container, '889ceddbb88e', 'angry_goodall']);
+```
+
+Same as the `remove` method it has a second argument (defaults to `false`) `$volumes` which allows you to remove the volumes associated with the containers by setting it to `true`.
+
+Keep in mind that all of the containers have to be stopped before they can be removed.
+
+
 ## The Docker\Container class
 
 The `Docker\Container` class is designed to help you manipulate containers. It has a few helper methods to set common runtime options.
@@ -164,7 +186,6 @@ $container->setEnv(['SYMFONY_ENV=prod', 'FOO=bar']);
 $container->setCmd(['/bin/echo', 'Hello Docker!']);
 
 $manager->run($container);
-
 
 printf('Container\'s id is %s', $container->getId());
 printf('Container\'s name is $s', $container->getName());

--- a/docs/image/remove.md
+++ b/docs/image/remove.md
@@ -1,0 +1,32 @@
+# Remove an image
+
+Using the [Docker client](../basic.md) you run
+
+```php
+$imageManager = $docker->getImageManager();
+
+$image1 = $manager->find('ubuntu', 'vivid');
+
+$manager->remove($image1);
+
+// OR
+
+$image2 = new Docker\Image();
+$image2->setId('69c02692b0c1');
+
+$manager->remove($image2);
+```
+
+The `remove` method has a second argument `$force` and a third one `$noprune`, both default to `false`.
+
+# Remove multiple images
+
+You can remove multiple images at once by passing an array of `Docker\Image` instances or strings (image id or image repository name and repository tag) to the `removeImages()` method.
+
+```php
+$manager->removeImages([$image, 'ubuntu:vivid', '69c02692b0c1']);
+```
+
+The method has the same second (`$force`) and third (`$noprune`) argument as the `remove` method.
+
+Keep in mind that all containers which are based on these images have to be removed before the image itself can be removed.

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -369,7 +369,7 @@ class ContainerManager
     }
 
     /**
-     * Delete multiple containers from docker server
+     * Remove multiple containers from docker server
      *
      * @param \Docker\Container[]|array $containers
      * @param boolean                   $volumes

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -369,6 +369,32 @@ class ContainerManager
     }
 
     /**
+     * Delete multiple containers from docker server
+     *
+     * @param \Docker\Container[]|array $containers
+     * @param boolean                   $volumes
+     *
+     * @throws \Docker\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Docker\Manager\ContainerManager
+     */
+    public function removeContainers(array $containers, $volumes = false)
+    {
+        foreach ($containers as $container) {
+            if (!$container instanceof Container) {
+                $containerId = $container;
+
+                $container = new Container();
+                $container->setId($containerId);
+            }
+
+            $this->remove($container, $volumes);
+        }
+
+        return $this;
+    }
+
+    /**
      * List process running inside a container
      *
      * @param Container $container

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -190,17 +190,17 @@ class ImageManager
     }
 
     /**
-     * Delete multiple images from docker daemon
+     * Remove multiple images from docker daemon
      *
-     * @param Image[]|array $images  Images to delete
-     * @param boolean       $force   Force deletion of image (default false)
-     * @param boolean       $noprune Do not delete parent images (default false)
+     * @param Image[]|array $images  Images to remove
+     * @param boolean       $force   Force removal of image (default false)
+     * @param boolean       $noprune Do not remove parent images (default false)
      *
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      *
      * @return ImageManager
      */
-    public function deleteImages(array $images, $force = false, $noprune = false)
+    public function removeImages(array $images, $force = false, $noprune = false)
     {
         foreach ($images as $image) {
             if (!$image instanceof Image) {
@@ -210,7 +210,7 @@ class ImageManager
                 $image->setId($imageId);
             }
 
-            $this->delete($image, $force, $noprune);
+            $this->remove($image, $force, $noprune);
         }
 
         return $this;

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -190,6 +190,33 @@ class ImageManager
     }
 
     /**
+     * Delete multiple images from docker daemon
+     *
+     * @param Image[]|array $images  Images to delete
+     * @param boolean       $force   Force deletion of image (default false)
+     * @param boolean       $noprune Do not delete parent images (default false)
+     *
+     * @throws \Docker\Exception\UnexpectedStatusCodeException
+     *
+     * @return ImageManager
+     */
+    public function deleteImages(array $images, $force = false, $noprune = false)
+    {
+        foreach ($images as $image) {
+            if (!$image instanceof Image) {
+                $imageId = $image;
+
+                $image = new Image();
+                $image->setId($imageId);
+            }
+
+            $this->delete($image, $force, $noprune);
+        }
+
+        return $this;
+    }
+
+    /**
      * Search for an image on Docker Hub.
      *
      * @param string $term term to search

--- a/src/Docker/Tests/Manager/ContainerManagerTest.php
+++ b/src/Docker/Tests/Manager/ContainerManagerTest.php
@@ -353,6 +353,23 @@ class ContainerManagerTest extends TestCase
         $manager->inspect($container);
     }
 
+    public function testRemoveContainers()
+    {
+        $containers = ['3360ea744df2', 'a412d121d015'];
+        $manager = $this
+            ->getMockBuilder('\Docker\Manager\ContainerManager')
+            ->setMethods(['remove'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $manager->expects($this->exactly(2))
+            ->method('remove')
+            ->with($this->isInstanceOf('\Docker\Container'), false)
+            ->will($this->returnSelf());
+
+        $manager->removeContainers($containers);
+    }
+
     public function testTop()
     {
         $container = new Container(['Image' => 'ubuntu:precise', 'Cmd' => ['sleep', '2']]);

--- a/src/Docker/Tests/Manager/ImageManagerTest.php
+++ b/src/Docker/Tests/Manager/ImageManagerTest.php
@@ -63,6 +63,23 @@ class ImageManagerTest extends TestCase
         $manager->inspect($image);
     }
 
+    public function testRemoveImages()
+    {
+        $containers = ['ubuntu:precise', '69c02692b0c1'];
+        $manager = $this
+            ->getMockBuilder('\Docker\Manager\ImageManager')
+            ->setMethods(['remove'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $manager->expects($this->exactly(2))
+            ->method('remove')
+            ->with($this->isInstanceOf('\Docker\Image'), false, false)
+            ->will($this->returnSelf());
+
+        $manager->removeImages($containers);
+    }
+
     public function testSearch()
     {
         $manager = $this->getManager();


### PR DESCRIPTION
From #30 `Utility function > Allow to easy remove a bunch of containers / image` I created a very basic method called `removeContainers` which takes an array of container ids (strings) or `Docker\Container` instances and passes them to the existing `remove` method. Same for ImageManager `deleteImages` expecting an array of image ids (strings..use ImageManager->find if you want to use the repo+tag) or `Docker\Image` instances.

Btw: Should we add a `findById` method to the ImageManager for simplicity? 
```php
$image = new Image();
$image->setId($imageId);
```
might seem odd to some developers.