### PR TITLE
Docker exec testing

### DIFF
--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -239,8 +239,12 @@ class ContainerManager
         if ($response->getStatusCode() !== "201") {
             throw UnexpectedStatusCodeException::fromResponse($response);
         }
-// why is the body empty at this point? Status code of 203 is fine, and content length is 74
+// why is the body empty at this point? Status code of 201 is fine, and content length is 74
 print_r('Status code=' . $response->getStatusCode(). "\n");
+$json=$response->json();
+var_dump($json);
+$body = json_decode($response->getBody(true));
+print_r('Body=' . $body . "\n");
 
 // why does the following fail with:
 // PHP Fatal error:  Call to undefined method GuzzleHttp\Message\Response::getContentLength() 
@@ -248,12 +252,8 @@ print_r('Status code=' . $response->getStatusCode(). "\n");
 //print_r('getContentLength=' . $response->getContentLength(). "\n");
 
 print_r('Response string=' . $response->__toString() . "\n");
-$body = json_decode($response->getBody(true));
-print_r('Body=' . $body . "\n");
 print_r('>>>> ');
 
-#$json=$response->json();
-#var_dump($json);
 /*
         $execid = $response->json()['Id'];
    print_r($execid);

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -242,7 +242,7 @@ class ContainerManager
 // why is the body empty at this point? Status code of 203 is fine, and content length is 74
 print_r('Status code=' . $response->getStatusCode(). "\n");
 
-// why does the follwoing fila with:
+// why does the following fail with:
 // PHP Fatal error:  Call to undefined method GuzzleHttp\Message\Response::getContentLength() 
 // see also http://api.guzzlephp.org/class-Guzzle.Http.Message.Response.html
 //print_r('getContentLength=' . $response->getContentLength(). "\n");
@@ -251,6 +251,7 @@ print_r('Response string=' . $response->__toString() . "\n");
 $body = json_decode($response->getBody(true));
 print_r('Body=' . $body . "\n");
 print_r('>>>> ');
+
 #$json=$response->json();
 #var_dump($json);
 /*

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -10,12 +10,6 @@ use Docker\Exception\ContainerNotFoundException;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\RequestException;
 
-# https://github.com/guzzle/log-subscriber
-use GuzzleHttp\Subscriber\Log\LogSubscriber;
-use GuzzleHttp\Subscriber\Log\Formatter;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-
 
 /**
  * Docker\Manager\ContainerManager
@@ -228,13 +222,6 @@ class ContainerManager
      */
     public function exec(Container $container)
     {
-      $log = new Logger('log');
-      // todo: Log the full request and response messages to stdout
-      $subscriber = new LogSubscriber(null, Formatter::DEBUG);
-      #$log->pushHandler(new StreamHandler('/tmp/requests.log'));
-      #$subscriber = new LogSubscriber($log);
-      $this->client->getEmitter()->attach($subscriber);
-
         $body = [
             'AttachStdin'  => false,
             'AttachStdout' => true,

--- a/src/Docker/Manager/exectest.php
+++ b/src/Docker/Manager/exectest.php
@@ -5,11 +5,6 @@
 chdir('/var/www/html/sites/all/libraries/composer/');
 require_once 'autoload.php';
 
-# (why do these not autoload)
-require_once "/var/www/html/sites/all/libraries/composer/guzzlehttp/log-subscriber/src/LogSubscriber.php";
-require_once "/var/www/html/sites/all/libraries/composer/guzzlehttp/log-subscriber/src/Formatter.php";
-require_once "/var/www/html/sites/all/libraries/composer/guzzlehttp/log-subscriber/src/SimpleLogger.php";
-
 $client = new Docker\Http\DockerClient(array(), 'unix:////tmp/socat.sock'); # /var/run/docker.sock
 $docker = new Docker\Docker($client);
 $manager = $docker->getContainerManager();

--- a/src/Docker/Manager/exectest.php
+++ b/src/Docker/Manager/exectest.php
@@ -12,12 +12,19 @@ $manager = $docker->getContainerManager();
 try {
   $lookfor='vanilla2';
   $container = $manager->find($lookfor);
-  $response = $manager->exec($container);
+  $foo = $manager->exec($container);
+#print_r($foo);
 
 } catch (Exception $e) {
-  #echo $e->getMessage();
+  echo $e->getMessage();
   #print_r($e->getResponse()->info);
   #print_r($e->getResponse()->__toString());
+  
+  #echo $e->getRequest();
+  #if ($e->hasResponse()) {
+  #  print_r($e->getResponse()->getStatusCode() . ' ' . $e->getResponse()->getReasonPhrase());
+  # echo $e->getResponse();
+  #}
 }
 
 print_r("\n");

--- a/src/Docker/Manager/exectest.php
+++ b/src/Docker/Manager/exectest.php
@@ -1,0 +1,31 @@
+#!/usr/bin/php
+<?php
+
+#chdir(dirname(__DIR__));
+chdir('/var/www/html/sites/all/libraries/composer/');
+require_once 'autoload.php';
+
+# (why do these not autoload)
+require_once "/var/www/html/sites/all/libraries/composer/guzzlehttp/log-subscriber/src/LogSubscriber.php";
+require_once "/var/www/html/sites/all/libraries/composer/guzzlehttp/log-subscriber/src/Formatter.php";
+require_once "/var/www/html/sites/all/libraries/composer/guzzlehttp/log-subscriber/src/SimpleLogger.php";
+
+$client = new Docker\Http\DockerClient(array(), 'unix:////tmp/socat.sock'); # /var/run/docker.sock
+$docker = new Docker\Docker($client);
+$manager = $docker->getContainerManager();
+
+try {
+  $lookfor='vanilla2';
+  $container = $manager->find($lookfor);
+  $response = $manager->exec($container);
+
+} catch (Exception $e) {
+  #echo $e->getMessage();
+  #print_r($e->getResponse()->info);
+  #print_r($e->getResponse()->__toString());
+}
+
+print_r("\n");
+
+
+


### PR DESCRIPTION
This PR / branch is for a discussion/help request, not for commit.  

Working on the docker exec feature, strange issue. The body  is coming back empty after the initial post.

the simple exectest.php script in this branch just calls 
$manager->exec($container);
in ContainerManager.php, the exec function is initially just doing a hard coded POST and one should get an ID back. However, the body is always empty, even thought the content length is 74.

The aim is to imitate the following which works fine with curl on the command line:

curl -X POST -v -H "Content-Type: application/json" http://127.0.0.1:2375/containers/vanilla2/exec -d '{ "AttachStdin":false,"AttachStdout":true,"AttachStderr":true, "Tty":false, "Cmd":["/bin/bash", "-c", "ls /var/www/html"] }'
..
* Connected to 127.0.0.1 (127.0.0.1) port 2375 (#0)
> POST /containers/vanilla2/exec HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 127.0.0.1:2375
> Accept: */*
> Content-Type: application/json
> Content-Length: 123
>
< HTTP/1.1 201 Created
< Content-Type: application/json
< Date: Tue, 27 Jan 2015 09:24:47 GMT
< Content-Length: 74
<
{"Id":"d214440b0505e2836f1ef5b68aecb6d142176b2eccd3a654ffbd5150c9b7e295"}
* Connection #0 to host 127.0.0.1 left intact


Running exectest.php  gives:
Status code=201
Response string=HTTP/1.1 201 Created
Content-Type: application/json
Date: Tue, 27 Jan 2015 13:34:23 GMT
Content-Length: 74
Connection: close


Body=
>>>>

Using "socat" to sniff traffic, the response send back by the docker server seems perfect:

POST /containers/vanilla2/exec HTTP/1.1\r
User-Agent: Guzzle/4.1.8 curl/7.35.0 PHP/5.5.9-1ubuntu4.5\r
content-type: application/json\r
Connection: close\r
Content-Length: 93\r
\r
{"AttachStdin":false,"AttachStdout":true,"AttachStderr":true,"Tty":false,"Cmd":["/bin/date"]}< 2015/01/27 13:36:00.676982  length=206 from=0 to=205
HTTP/1.1 201 Created\r
Content-Type: application/json\r
Date: Tue, 27 Jan 2015 13:36:00 GMT\r
Content-Length: 74\r
Connection: close\r
\r
{"Id":"41b104f139a64dbdffdac81fc58d485034648bc3b349d619391f08da551133aa"}

Question: any idea why guzzle seems to be sending an empty body back?

