### PR TITLE
ContainerManager::copy(): Copy files or folders from a container to a tar stream

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -173,18 +173,14 @@ printf('Container\'s exit code is %d', $container->getExitCode());
 
 ## Copy files or folders from a container
 
-File and folders can be downloaded as a tar file from the container. The copy() function allows a folder/file to be downloaded as tar stream and copyToDisk() saves the result as a tar file.
-In the following example the /etc/default folder from a ubuntu container called vanilla is downloaded to /tmp/resource.tar.
+Files and folders can be downloaded as a tar file from the container. The `copy()` function allows a folder/file to be downloaded as tar stream and `copyToDisk()` saves the result as a tar file.
+In the following example the `/etc/default` folder from an Ubuntu container called vanilla is downloaded to `/tmp/file.tar`.
 
 ```php
 <?php
 
-$lookfor = 'vanilla';
-$source = '/etc/default'; 
-$tarFileName  = "/tmp/resource.tar";  
-
-$container = $manager->find($lookfor);
-$manager->copyToDisk($container, $source, $tarFileName);
+$container = $manager->find('vanilla');
+$manager->copyToDisk($container, '/etc/default', '/tmp/file.tar');
 ```
 
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,4 +1,4 @@
-## Dealing with containers
+# Dealing with containers
 
 ## Running a container
 
@@ -200,4 +200,3 @@ $ports->add(42);
 
 $container->setExposedPorts($ports);
 ```
-

--- a/docs/container.md
+++ b/docs/container.md
@@ -174,17 +174,17 @@ printf('Container\'s exit code is %d', $container->getExitCode());
 ## Copy files or folders from a container
 
 File and folders can be downloaded as a tar file from the container. The copy() function allows a folder/file to be downloaded as tar stream and copyToDisk() saves the result as a tar file.
-In the following example the /etc/default folder from a ubuntu container called vanilla2 is downloaded to /tmp/resource.tar.
+In the following example the /etc/default folder from a ubuntu container called vanilla is downloaded to /tmp/resource.tar.
 
 ```php
 <?php
 
-$lookfor = 'vanilla2';      
-$resource = '/etc/default'; 
+$lookfor = 'vanilla';
+$source = '/etc/default'; 
 $tarFileName  = "/tmp/resource.tar";  
 
 $container = $manager->find($lookfor);
-$manager->copyToDisk($container, $resource, $tarFileName);
+$manager->copyToDisk($container, $source, $tarFileName);
 ```
 
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,4 +1,4 @@
-# Dealing with containers
+## Dealing with containers
 
 ## Running a container
 
@@ -171,6 +171,23 @@ printf('Container\'s name is $s', $container->getName());
 printf('Container\'s exit code is %d', $container->getExitCode());
 ```
 
+## Copy files or folders from a container
+
+File and folders can be downloaded as a tar file from the container. The copy() function allows a folder/file to be downloaded as tar stream and copyToDisk() saves the result as a tar file.
+In the following example the /etc/default folder from a ubuntu container called vanilla2 is downloaded to /tmp/resource.tar.
+
+```php
+<?php
+
+$lookfor = 'vanilla2';      
+$resource = '/etc/default'; 
+$tarFileName  = "/tmp/resource.tar";  
+
+$container = $manager->find($lookfor);
+$manager->copyToDisk($container, $resource, $tarFileName);
+```
+
+
 ### Configuring exposed ports
 
 Use the `Docker\PortCollection` class to manage exposed ports:
@@ -183,3 +200,4 @@ $ports->add(42);
 
 $container->setExposedPorts($ports);
 ```
+

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -172,6 +172,32 @@ class ContainerManager
         return $this;
     }
 
+
+    /**
+     * Copy files or folders from a container
+     *
+     * @param \Docker\Container $container
+     * @param                   $resource file or folder name
+     *
+     * @throws \Docker\Exception\UnexpectedStatusCodeException
+     *
+     * @return tarfile stream
+     */
+    public function copy(Container $container, $resource)
+    {
+        $response = $this->client->post(['/containers/{id}/copy', ['id' => $container->getId()]], [
+            'body'         => Json::encode(["Resource" => "$resource"]),
+            'headers'      => ['content-type' => 'application/json'],
+        ]);
+
+        if ($response->getStatusCode() !== "200") {
+            throw UnexpectedStatusCodeException::fromResponse($response);
+        }
+
+        return $response->getBody();
+    }
+
+
     /**
      * Run a container (create, attach, start and wait)
      *

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -177,16 +177,16 @@ class ContainerManager
      * Copy files or folders from a container
      *
      * @param \Docker\Container $container
-     * @param                   $resource file or folder name
+     * @param string            $source file or folder name
      *
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      *
-     * @return tarfile stream
+     * @return Guzzle\Stream\Stream Tarfile stream
      */
-    public function copy(Container $container, $resource)
+    public function copy(Container $container, $source)
     {
         $response = $this->client->post(['/containers/{id}/copy', ['id' => $container->getId()]], [
-            'body'         => Json::encode(["Resource" => "$resource"]),
+            'body'         => Json::encode(["Resource" => $source]),
             'headers'      => ['content-type' => 'application/json'],
         ]);
 
@@ -196,6 +196,31 @@ class ContainerManager
 
         return $response->getBody();
     }
+
+
+    /**
+     * Save files pulled by copy() to disk 
+     *
+     * @param \Docker\Container $container
+     * @param string            $source file or folder name
+     * @param string            $destination file
+     *
+     * @throws \Docker\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Docker\Manager\ContainerManager
+     */
+
+    public function copyToDisk(Container $container, $source, $destination)
+    {
+        $stream = $this->copy($container, $source);
+
+        $output = fopen($destination, 'w+');
+        stream_copy_to_stream($stream->detach(), $output);
+        fclose($output);
+
+        return $this;
+    }
+
 
 
     /**

--- a/src/Docker/Tests/Manager/ContainerManagerTest.php
+++ b/src/Docker/Tests/Manager/ContainerManagerTest.php
@@ -411,7 +411,7 @@ class ContainerManagerTest extends TestCase
         $manager->remove($container);
     }
 
-    public function testcopyToDisk()
+    public function testCopyToDisk()
     {
        $container = new Container(['Image' => 'ubuntu:precise', 'Cmd' => ['touch', '/etc/default/docker-php-test']]);
        $manager = $this->getManager();

--- a/src/Docker/Tests/Manager/ContainerManagerTest.php
+++ b/src/Docker/Tests/Manager/ContainerManagerTest.php
@@ -411,6 +411,23 @@ class ContainerManagerTest extends TestCase
         $manager->remove($container);
     }
 
+    public function testcopyToDisk()
+    {
+       $container = new Container(['Image' => 'ubuntu:precise', 'Cmd' => ['touch', '/etc/default/docker-php-test']]);
+       $manager = $this->getManager();
+       $manager->run($container);
+       $manager->wait($container);
+
+       $tarFileName  = tempnam(sys_get_temp_dir(), 'testcopyToDisk.tar');
+       $manager->copyToDisk($container, '/etc/default', $tarFileName);
+
+       exec('/usr/bin/env tar -tf '.$tarFileName, $output);
+       $this->assertContains('default/docker-php-test', $output);
+
+       unlink($tarFileName);
+       $manager->remove($container);
+    }
+
     public function testLogs()
     {
         $container = new Container(['Image' => 'ubuntu:precise', 'Cmd' => ['echo', 'test']]);


### PR DESCRIPTION
Api for http://docs.docker.com/reference/api/docker_remote_api_v1.16/#copy-files-or-folders-from-a-container

Example usage

```php
$lookfor = 'vanilla2';
$container = $manager->find($lookfor);
$resource = '/etc/default';      # copy this whole folder
$exportStream = $manager->copy($container, $resource);
$tarFileName  = "/tmp/resource.tar";
$tarFile      = fopen($tarFileName, 'w+');
stream_copy_to_stream($exportStream->detach(), $tarFile);
fclose($tarFile);
echo "$tarFileName written\n";

