### PR TITLE
exec() and execstart() in ContainerManager

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -186,8 +186,8 @@ $container->setExposedPorts($ports);
 
 ## Exec: running command within an existing running container.
 
-Running a command inside an running container is done in two steps: create an exec instance (identified by a hash value) and starting that instance and reading the returned data.
-Example: connect to the contained called 'vanilla2', create an exec for 'ls /var/www/html' (within a bash shell) and run it:
+Running a command inside a running container is done in two steps: create an exec instance (identified by a hash value) and starting that instance (and then reading the returned data).
+Example: connect to the container called 'vanilla2', create an exec for 'ls /var/www/html' (within a bash shell) and run it:
 ```php
 <?php
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -183,3 +183,20 @@ $ports->add(42);
 
 $container->setExposedPorts($ports);
 ```
+
+## Exec: running command within an existing running container.
+
+Running a command inside an running container is done in two steps: create an exec instance (identified by a hash value) and starting that instance and reading the returned data.
+Example: connect to the contained called 'vanilla2', create an exec for 'ls /var/www/html' (within a bash shell) and run it:
+```php
+<?php
+
+  $lookfor='vanilla2';
+  $container = $manager->find($lookfor);
+  $execid = $manager->exec($container, ["/bin/bash", "-c", "ls /var/www/html"]);
+  $result=$manager->execstart($execid);
+  print_r("Result= <" . $result->__toString() . ">\n");
+```
+Note that after an exec has been created it can be run several times, e.g. an exec for '/bin/date' would return a different value each time execstart() is called.
+ 
+

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -222,7 +222,7 @@ class ContainerManager
      *
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      *
-     * @return ID of the executive
+     * @return string ID of the executive
      */
     public function exec(Container $container, array $cmd = [], $attachstdin = false, $attachstdout = true, $attachstderr = true, $tty = false)
     {
@@ -242,7 +242,7 @@ class ContainerManager
             throw UnexpectedStatusCodeException::fromResponse($response);
         }
 
-      return $response->json()['Id'];
+        return $response->json()['Id'];
     }
 
     /**
@@ -251,13 +251,13 @@ class ContainerManager
      * execstart() on that ID will return a different value each time.
      * todo: how are instances created by exec() and used by execstart() removed/cleanedup?
      *
-     * @param string   $id       identifier from exec()
+     * @param string   $execid       identifier from exec()
      * @param boolean  $detach
      * @param boolean  $tty  
      *
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      *
-     * @return Guzzle Stream
+     * @return \GuzzleHttp\Stream\Stream
      */
 
     public function execstart($execid, $detach = false, $tty = false)  

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -10,7 +10,6 @@ use Docker\Exception\ContainerNotFoundException;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\RequestException;
 
-
 /**
  * Docker\Manager\ContainerManager
  */
@@ -212,6 +211,7 @@ class ContainerManager
 
     /**
      * Execute a command in a running container
+     * i.e. create an executive, which will be run by execstart()
      *
      * @param \Docker\Container     $container
      * @param array    $cmd          command to run
@@ -242,11 +242,14 @@ class ContainerManager
             throw UnexpectedStatusCodeException::fromResponse($response);
         }
 
-       return $response->json()['Id'];
+      return $response->json()['Id'];
     }
 
     /**
-     * Start an executive  defined from exec()
+     * Start an executive defined from exec()
+     * This can be resude several times, so if the command /bin/date in defined in exec()
+     * execstart() on that ID will return a different value each time.
+     * todo: how are instances created by exec() and used by execstart() removed/cleanedup?
      *
      * @param string   $id       identifier from exec()
      * @param boolean  $detach
@@ -255,7 +258,6 @@ class ContainerManager
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      *
      * @return Guzzle Stream
-     * todo: how are instances created by exec() and used by execstart() removed/cleanedup?
      */
 
     public function execstart($execid, $detach = false, $tty = false)  


### PR DESCRIPTION
try it out

```php
try {
  $lookfor='vanilla2';
  $container = $manager->find($lookfor);
  $execid = $manager->exec($container, ['/bin/date']);
  # other example: $execid = $manager->exec($container, ["/bin/bash", "-c", "ls /var/www/html"]);
  print_r("Exec ID= <" . $execid. ">\n");
  $result=$manager->execstart($execid);
  print_r("Result= <" . $result->__toString() . ">\n");
} catch (Exception $e) {
  echo $e->getMessage();
}
```

FYI this equivalent to doing the following on the command line directly with the docker api:

```
curl -X POST -H "Content-Type: application/json" http://127.0.0.1:2375/containers/vanilla2/exec -d '{ "AttachStdin":false,"AttachStdout":true,"AttachStderr":true, "Tty":false, "Cmd":["/bin/date"] }'

{"Id":"213f4f0abd592b302a6af43637f4422f6387b63a9759643b3e6024655099b298"}

curl -X POST -H "Content-Type: application/json" http://127.0.0.1:2375/exec/213f4f0abd592b302a6af43637f4422f6387b63a9759643b3e6024655099b298/start -d '{ "Detach":false,"Tty":false}'
```