### PR TITLE
Travis changes - Symfony stable + disable hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+#  - hhvm
 
 env:
   - $SYMFONY_VERSION='2.3.*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - $SYMFONY_VERSION='2.3.*'
   - $SYMFONY_VERSION='2.4.*'
   - $SYMFONY_VERSION='2.5.*'
-  - $SYMFONY_VERSION='2.6.*@dev'
+  - $SYMFONY_VERSION='2.6.*'
 
 matrix:
     allow_failures:


### PR DESCRIPTION
I think we should disable hhvm while it fails..doesn’t help us & just uses up Travis resources.