### PR TITLE
Fix link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The recommended way to install Docker PHP is of course to use [Composer](http://
 Usage
 -----
 
-See [the documentation](https://github.com/stage1/docker-php/blob/master/doc/usage.md).
+See [the documentation](https://github.com/stage1/docker-php/tree/master/docs).
 
 Unit Tests
 ----------


### PR DESCRIPTION
Since 37aaf6c1ad0165b7129460a521b2fdb06f411409 there is no usage.md file to point to. So the "the documentation" link sends to a 404.
The links on the index.md files does not work, and the http://docker-php.readthedocs.org/ page does not seems to be ready so, we just link to the docs folder on github.