### PR TITLE
Add optional parameters to ImageManager::findAll

### DIFF
--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -30,14 +30,18 @@ class ImageManager
     /**
      * Get all images from docker daemon
      *
+     * @param array $params an array of query parameters
+     *
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      *
      * @return Image[]
      */
-    public function findAll()
+    public function findAll(array $params = [])
     {
         /** @var Response $response */
-        $response = $this->client->get('/images/json');
+        $response = $this->client->get('/images/json', [
+            'query' => $params
+        ]);
 
         if ($response->getStatusCode() !== "200") {
             throw UnexpectedStatusCodeException::fromResponse($response);

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -30,14 +30,25 @@ class ImageManager
     /**
      * Get all images from docker daemon
      *
-     * @param array $params an array of query parameters
+     * @param boolean $dangling Filter dangling images
+     * @param boolean $all      List all images including untagged
      *
      * @throws \Docker\Exception\UnexpectedStatusCodeException
      *
      * @return Image[]
      */
-    public function findAll(array $params = [])
+    public function findAll($dangling = false, $all = false)
     {
+        $params = [];
+
+        if ($all) {
+            $params['all'] = 1;
+        }
+
+        if ($dangling) {
+            $params['dangling'] = 1;
+        }
+
         /** @var Response $response */
         $response = $this->client->get('/images/json', [
             'query' => $params

--- a/src/Docker/Tests/Manager/ImageManagerTest.php
+++ b/src/Docker/Tests/Manager/ImageManagerTest.php
@@ -52,6 +52,27 @@ class ImageManagerTest extends TestCase
         $this->assertGreaterThanOrEqual(1, count($manager->findAll()));
     }
 
+    public function testFindAllAll()
+    {
+        $manager = $this->getManager();
+
+        $images1 = $manager->findAll();
+        $images2 = $manager->findAll(['all' => 1]);
+
+        $this->assertInternalType('array', $images2);
+        $this->assertGreaterThan(count($images1), count($images2));
+    }
+
+    public function testFindAllDangling()
+    {
+        $manager = $this->getManager();
+
+        $images = $manager->findAll(['dangling' => 1]);
+
+        $this->assertInternalType('array', $images);
+        $this->assertGreaterThanOrEqual(1, count($images));
+    }
+
     public function testRemove()
     {
         $manager = $this->getManager();

--- a/src/Docker/Tests/Manager/ImageManagerTest.php
+++ b/src/Docker/Tests/Manager/ImageManagerTest.php
@@ -57,7 +57,7 @@ class ImageManagerTest extends TestCase
         $manager = $this->getManager();
 
         $images1 = $manager->findAll();
-        $images2 = $manager->findAll(['all' => 1]);
+        $images2 = $manager->findAll(false, true);
 
         $this->assertInternalType('array', $images2);
         $this->assertGreaterThan(count($images1), count($images2));
@@ -67,7 +67,7 @@ class ImageManagerTest extends TestCase
     {
         $manager = $this->getManager();
 
-        $images = $manager->findAll(['dangling' => 1]);
+        $images = $manager->findAll(true);
 
         $this->assertInternalType('array', $images);
         $this->assertGreaterThanOrEqual(1, count($images));


### PR DESCRIPTION
Allows `$imageManager->findAll(['all' => true]);` and `$imageManager->findAll(['dangling' => true]);`

See http://docs.docker.com/reference/api/docker_remote_api_v1.17/#list-images

Fixes #97 