### PR TITLE
Fix Travis builds (making Docker run again and actually use Symfony version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ php:
 #  - hhvm
 
 env:
-  - $SYMFONY_VERSION='2.3.*'
-  - $SYMFONY_VERSION='2.4.*'
-  - $SYMFONY_VERSION='2.5.*'
+#  - $SYMFONY_VERSION='2.3.*'
   - $SYMFONY_VERSION='2.6.*'
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -y slirp lxc aufs-tools cgroup-lite
   - sudo mkdir -p /var/lib/docker
-#  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.4.1/lxc-docker-1.4.1_1.4.1_amd64.deb
-  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.5.0/lxc-docker-1.5.0_1.5.0_amd64.deb
+  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.4.1/lxc-docker-1.4.1_1.4.1_amd64.deb
+# The Docker 1.5.0 deb package seems faulty..let’s use 1.4.1 until there is a fix
+#  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.5.0/lxc-docker-1.5.0_1.5.0_amd64.deb
   - sudo dpkg -i lxc-docker_amd64.deb
   - curl -sLo linux https://github.com/jpetazzo/sekexe/raw/master/uml
   - chmod +x linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -y slirp lxc aufs-tools cgroup-lite
   - sudo mkdir -p /var/lib/docker
-  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.4.1/lxc-docker-1.4.1_1.4.1_amd64.deb
-#  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.5.0/lxc-docker-1.5.0_1.5.0_amd64.deb
+#  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.4.1/lxc-docker-1.4.1_1.4.1_amd64.deb
+  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.5.0/lxc-docker-1.5.0_1.5.0_amd64.deb
   - sudo dpkg -i lxc-docker_amd64.deb
   - curl -sLo linux https://github.com/jpetazzo/sekexe/raw/master/uml
   - chmod +x linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - sudo apt-get install -y slirp lxc aufs-tools cgroup-lite
   - sudo mkdir -p /var/lib/docker
   - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.4.1/lxc-docker-1.4.1_1.4.1_amd64.deb
-# The Docker 1.5.0 deb package seems faulty..let’s use 1.4.1 until there is a fix
+# The Docker 1.5.0 deb package seems faulty..let's use 1.4.1 until there is a fix
 #  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.5.0/lxc-docker-1.5.0_1.5.0_amd64.deb
   - sudo dpkg -i lxc-docker_amd64.deb
   - curl -sLo linux https://github.com/jpetazzo/sekexe/raw/master/uml

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - chmod +x linux
   - composer require --no-update symfony/filesystem:${SYMFONY_VERSION}
   - composer require --no-update symfony/process:${SYMFONY_VERSION}
-  - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
+  - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source install
 
 script:
   - sudo ./linux quiet mem=2G rootfstype=hostfs rw eth0=slirp,,/usr/bin/slirp-fullbolt init=$(pwd)/docker.sh WORKDIR=$(pwd) HOME=$(pwd) PATH=$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ php:
 #  - hhvm
 
 env:
-#  - $SYMFONY_VERSION='2.3.*'
-  - $SYMFONY_VERSION='2.6.*'
+  matrix:
+    - SYMFONY_VERSION='2.3.*'
+    - SYMFONY_VERSION='2.6.*'
 
 matrix:
     allow_failures:
@@ -26,6 +27,8 @@ install:
   - sudo dpkg -i lxc-docker_amd64.deb
   - curl -sLo linux https://github.com/jpetazzo/sekexe/raw/master/uml
   - chmod +x linux
+  - composer require --no-update symfony/filesystem:${SYMFONY_VERSION}
+  - composer require --no-update symfony/process:${SYMFONY_VERSION}
   - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,18 @@ matrix:
         - php: hhvm
 
 install:
-  - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
-  - sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
-  - sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
-  - sudo apt-get update
-  - sudo mkdir -p /var/lib/docker
   - echo exit 101 | sudo tee /usr/sbin/policy-rc.d
   - sudo chmod +x /usr/sbin/policy-rc.d
-  - sudo apt-get install -y slirp lxc lxc-docker aufs-tools cgroup-lite
+  - sudo apt-get update -qq
+  - sudo apt-get install -y slirp lxc aufs-tools cgroup-lite
+  - sudo mkdir -p /var/lib/docker
+  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.4.1/lxc-docker-1.4.1_1.4.1_amd64.deb
+#  - curl -sLo lxc-docker_amd64.deb http://get.docker.io/ubuntu/pool/main/l/lxc-docker-1.5.0/lxc-docker-1.5.0_1.5.0_amd64.deb
+  - sudo dpkg -i lxc-docker_amd64.deb
   - curl -sLo linux https://github.com/jpetazzo/sekexe/raw/master/uml
   - chmod +x linux
+  - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
 
 script:
-  - ./linux quiet mem=2G rootfstype=hostfs rw eth0=slirp,,/usr/bin/slirp-fullbolt init=$(pwd)/docker.sh WORKDIR=$(pwd) HOME=$(pwd) PATH=$PATH
+  - sudo ./linux quiet mem=2G rootfstype=hostfs rw eth0=slirp,,/usr/bin/slirp-fullbolt init=$(pwd)/docker.sh WORKDIR=$(pwd) HOME=$(pwd) PATH=$PATH
   - bash -c "exit $(cat /tmp/build.status)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ php:
 
 env:
   matrix:
-    - SYMFONY_VERSION='2.3.*'
-    - SYMFONY_VERSION='2.6.*'
+    - SYMFONY_VERSION="2.3.*"
+    - SYMFONY_VERSION="2.6.*"
 
 matrix:
-    allow_failures:
-        - php: hhvm
+  allow_failures:
+    - php: hhvm
 
 install:
   - echo exit 101 | sudo tee /usr/sbin/policy-rc.d


### PR DESCRIPTION
After @joelwurtz already tried several ways to fix docker on the `fix/travis` branch I’m giving it a shot too.

Just some notes:
Travis CI changed the cookbooks which might have caused the issues..compare: https://github.com/travis-ci/travis-cookbooks/compare/5736160...23bb455#commit_comments_bucket

I noticed something REALLY unnecessary: the env matrix isn’t actually used!! This will be fixed later.