### PR TITLE
New api function: Rename a container

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -205,6 +205,17 @@ $ports->add(42);
 $container->setExposedPorts($ports);
 ```
 
+## Rename: Changing the human readable name of a container
+
+Rename the container called vanilla1 to vanilla2:
+```php
+<?php
+
+$container = $manager->find('vanilla1');
+$manager->rename($container,'vanilla2');
+```
+
+
 ## Exec: Run a process within an existing running container.
 
 Running a process inside a running container is done in two steps: create an exec instance (identified by a hash value) and starting that instance (and then reading the returned data).

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -615,4 +615,27 @@ class ContainerManager
             throw UnexpectedStatusCodeException::fromResponse($response);
         }
     }
+
+    /**
+     * Rename a container (API v1.17)
+     *
+     * @param Container $container
+     * @param string $newname
+     *
+     * @throws \Docker\Exception\UnexpectedStatusCodeException
+     */
+    public function rename(Container $container, $newname)
+    {
+        $response = $this->client->post(['/containers/{id}/rename?name={newname}', [
+            'id'      => $container->getId(),
+            'newname' => $newname
+        ]]);
+
+        if ($response->getStatusCode() !== "204") {
+            throw UnexpectedStatusCodeException::fromResponse($response);
+        }
+
+        return $this;
+    }
+
 }

--- a/src/Docker/Tests/Manager/ContainerManagerTest.php
+++ b/src/Docker/Tests/Manager/ContainerManagerTest.php
@@ -534,4 +534,18 @@ class ContainerManagerTest extends TestCase
         $this->assertEquals(1, $type);
         $this->assertEquals('output', $output);
     }
+
+    public function testRename()
+    {
+        $container = new Container(['Image' => 'ubuntu:precise', 'Cmd' => ['/bin/true']]);
+
+        $manager = $this->getManager();
+        $manager->create($container);
+        $manager->start($container);
+        $manager->rename($container, 'FoobarRenamed');
+
+        $runtimeInformations = $container->getRuntimeInformations();
+		
+        $this->assertInstanceOf('Docker\\Container', $manager->find('FoobarRenamed'));
+    }
 }

--- a/src/Docker/Tests/Manager/ContainerManagerTest.php
+++ b/src/Docker/Tests/Manager/ContainerManagerTest.php
@@ -547,5 +547,7 @@ class ContainerManagerTest extends TestCase
         $runtimeInformations = $container->getRuntimeInformations();
 		
         $this->assertInstanceOf('Docker\\Container', $manager->find('FoobarRenamed'));
+        $manager->stop($container);   // cleanup
+        $manager->remove($container);
     }
 }


### PR DESCRIPTION

The latest API allows containers to be renamed.
http://docs.docker.com/reference/api/docker_remote_api_v1.17/#rename-a-container

Example usage:

```
$container = $manager->find('mycontainer');
$ret = $manager->rename($container, 'mynewcontainer');
```