### PR TITLE
fix broken documentation URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 <h2>
 <a name="usage" class="anchor" href="#usage"><span class="octicon octicon-link"></span></a>Usage</h2>
 
-<p>See <a href="https://github.com/stage1/docker-php/blob/master/doc/usage.md">the documentation</a>.</p>
+<p>See <a href="https://docker-php.readthedocs.org/en/latest/">the documentation</a>.</p>
 
 <h2>
 <a name="unit-tests" class="anchor" href="#unit-tests"><span class="octicon octicon-link"></span></a>Unit Tests</h2>


### PR DESCRIPTION
docker-php doc has been moved to readthedocs.org