### PR TITLE
Update ImageManager.php: correctly explode image names with port number and tag

### DIFF
--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -46,7 +46,7 @@ class ImageManager
         }
 
         if ($dangling) {
-            $params['dangling'] = 1;
+            $params['filters'] = ['dangling' => true];
         }
 
         /** @var Response $response */


### PR DESCRIPTION
Fix for exploding an image such as `registry.example.com:5000/my-image:latest`