### PR TITLE
Fixing $dangling parameter in findAll

### DIFF
--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -46,7 +46,7 @@ class ImageManager
         }
 
         if ($dangling) {
-            $params['dangling'] = 1;
+            $params['filters'] = ['dangling' => true];
         }
 
         /** @var Response $response */


### PR DESCRIPTION
The API expects a "filters" parameter with a key value pair for "dangling".

This fix ensures only dangling images are returned ("<none>:<none>").

Tested on API v1.20 by running `docker images -f dangling=true -a` and comparing the results.

https://docs.docker.com/reference/api/docker_remote_api_v1.17/#list-images