### PR TITLE
Extending container name validation pattern to [a-zA-Z0-9][a-zA-Z0-9_.-]

### DIFF
--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -193,7 +193,7 @@ class Container
      */
     public function setName($name)
     {
-        if (!preg_match("/^\/?[a-zA-Z0-9_-]+$/", $name)) {
+        if (!preg_match("/^\/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$/", $name)) {
             throw new \Exception("Name was not correctly formatted.", 1);
         }
 

--- a/src/Docker/Tests/ContainerTest.php
+++ b/src/Docker/Tests/ContainerTest.php
@@ -29,6 +29,12 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         $container->setName('Foobar');
 
         $this->assertEquals('Foobar', $container->getName());
+
+        $container->setName('Foo-Bar');
+        $this->assertEquals('Foo-Bar', $container->getName());
+
+        $container->setName('Foo-Bar_1.2.3');
+        $this->assertEquals('Foo-Bar_1.2.3', $container->getName());
     }
 
     public function testValidContainerName()
@@ -51,4 +57,26 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('Exception', 'Name was not correctly formatted.');
         $container->setName('Foo!');
     }
+
+    public function testInvalidContainerNameThree()
+    {
+        $container = new Container();
+        $this->setExpectedException('Exception', 'Name was not correctly formatted.');
+        $container->setName('-FooBar');
+    }
+
+    public function testInvalidContainerNameFour()
+    {
+        $container = new Container();
+        $this->setExpectedException('Exception', 'Name was not correctly formatted.');
+        $container->setName('.FooBar');
+    }
+
+    public function testInvalidContainerNameFive()
+    {
+        $container = new Container();
+        $this->setExpectedException('Exception', 'Name was not correctly formatted.');
+        $container->setName('_FooBar');
+    }
+
 }


### PR DESCRIPTION
Docker allows a little more characters to names, such as dots, and forbids names to begin with - or _.

This PR improves the regexp name. It includes unit tests.