### PR TITLE
Fix image name parsing (allowing repositories with ports).

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Docker PHP
 
 **Docker PHP** (for lack of a better name) is a [Docker](http://docker.com/) client written in PHP. This library is still a work in progress. Not much is supported yet, but the goal is to reach 100% API support.
 
-The test suite currently passes against the [Docker Remote API v1.17](http://docs.docker.com/reference/api/docker_remote_api_v1.17/).
+The test suite currently passes against the [Docker Remote API v1.20](http://docs.docker.com/reference/api/docker_remote_api_v1.20/).
 
 [![Documentation Status](https://readthedocs.org/projects/docker-php/badge/?version=latest)](http://docker-php.readthedocs.org/en/latest/) [![Travis-CI](https://travis-ci.org/stage1/docker-php.svg?branch=master)](https://travis-ci.org/stage1/docker-php) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/stage1/docker-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/stage1/docker-php/?branch=master)
 

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -338,9 +338,8 @@ class Container
             $repository = $this->config['Image'];
             $tag        = 'latest';
 
-            if(preg_match('/^(.*):([^:]*)/', $this->config['Image'], $matches)) {
-                $repository = $matches[1];
-                $tag = $matches[2];
+            if (preg_match('/:/', $this->config['Image'])) {
+                list($repository, $tag) = explode(':', $this->config['Image']);
             }
 
             $this->image = new Image($repository, $tag);

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -338,8 +338,9 @@ class Container
             $repository = $this->config['Image'];
             $tag        = 'latest';
 
-            if (preg_match('/:/', $this->config['Image'])) {
-                list($repository, $tag) = explode(':', $this->config['Image']);
+            if(preg_match('/^(.*):([^:]*)/', $this->config['Image'], $matches)) {
+                $repository = $matches[1];
+                $tag = $matches[2];
             }
 
             $this->image = new Image($repository, $tag);

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -335,14 +335,8 @@ class Container
     public function getImage()
     {
         if (!$this->image instanceof Image) {
-            $repository = $this->config['Image'];
-            $tag        = 'latest';
-
-            if (preg_match('/:/', $this->config['Image'])) {
-                list($repository, $tag) = explode(':', $this->config['Image']);
-            }
-
-            $this->image = new Image($repository, $tag);
+            $this->image = new Image();
+            $this->image->setRepoTag($this->config['Image']);
         }
 
         return $this->image;

--- a/src/Docker/Exception/InvalidRepoTagException.php
+++ b/src/Docker/Exception/InvalidRepoTagException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Docker\Exception;
+
+use Docker\Exception as BaseException;
+
+/**
+ * Docker\Exception\PortNotFoundException
+ */
+class InvalidRepoTagException extends BaseException
+{
+    /**
+     * @param string  $repoTag
+     */
+    public function __construct($repoTag)
+    {
+        parent::__construct(sprintf('Invalid repoTag: %s', $repoTag));
+    }
+}

--- a/src/Docker/Image.php
+++ b/src/Docker/Image.php
@@ -134,6 +134,43 @@ class Image
         return $this;
     }
 
+    /**
+     * Validate repoTag format.
+     *
+     * @param string $repoTag The repository/tag to validate
+     *
+     * @return Array with repository & tag key sets if valid, FALSE if not.
+     */
+    public static function parseRepoTag($repoTag)
+    {
+        $ret = preg_match('/^(.*):([^:]*)/', $repoTag, $matches);
+        if (1 !== $ret) {
+            return false;
+        }
 
+        return array(
+            'repository' => $matches[1],
+            'tag' => $matches[2]
+        );
+    }
 
+    /**
+     * Set repository / tag if repoTag is valid.
+     *
+     * @param string $repoTag The repository/tag to set to the image.
+     *
+     * @return bool TRUE is valid & set, FALSE if not.
+     */
+    public function setRepoTag($repoTag)
+    {
+        $parsedRepoTag = $this->parseRepoTag($repoTag);
+        if (false === $parsedRepoTag) {
+            return false;
+        }
+
+        $this->setRepository($parsedRepoTag['repository']);
+        $this->setTag($parsedRepoTag['tag']);
+
+        return true;
+    }
 }

--- a/src/Docker/Image.php
+++ b/src/Docker/Image.php
@@ -2,6 +2,8 @@
 
 namespace Docker;
 
+use Docker\Exception\InvalidRepoTagException;
+
 /**
  * Docker\Image
  */
@@ -140,12 +142,12 @@ class Image
      * @param string $repoTag The repository/tag to validate
      *
      * @return Array with repository & tag key sets if valid, FALSE if not.
+     * @throws InvalidRepoTagException if repoTag can not be parsed.
      */
     public static function parseRepoTag($repoTag)
     {
-        $ret = preg_match('/^(.*):([^:]*)/', $repoTag, $matches);
-        if (1 !== $ret) {
-            return false;
+        if (1 !== preg_match('/^(.*):([^:]*)/', $repoTag, $matches)) {
+            throw new InvalidRepoTagException($repoTag);
         }
 
         return array(
@@ -160,13 +162,11 @@ class Image
      * @param string $repoTag The repository/tag to set to the image.
      *
      * @return bool TRUE is valid & set, FALSE if not.
+     * @throws InvalidRepoTagException if repoTag can not be parsed.
      */
     public function setRepoTag($repoTag)
     {
         $parsedRepoTag = $this->parseRepoTag($repoTag);
-        if (false === $parsedRepoTag) {
-            return false;
-        }
 
         $this->setRepository($parsedRepoTag['repository']);
         $this->setTag($parsedRepoTag['tag']);

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -682,6 +682,8 @@ class ContainerManager
         if ($response->getStatusCode() !== "204") {
             throw UnexpectedStatusCodeException::fromResponse($response);
         }
+
+        $this->inspect($container);
     }
 
     /**

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -72,7 +72,13 @@ class ImageManager
             $image->setCreated($data['Created']);
 
             foreach ($data['RepoTags'] as $repoTag) {
-                list($repository, $tag) = explode(':', $repoTag);
+                $ret = preg_match('/^(.*):([^:]*)/', $repoTag, $matches);
+                if(1 !== $ret) {
+                    throw new APIException(sprintf('Can not parse repotag %s.', $repoTag));
+                }
+
+                $repository = $matches[1];
+                $tag = $matches[2];
 
                 $tagImage = clone $image;
                 $tagImage->setRepository($repository);

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -72,13 +72,7 @@ class ImageManager
             $image->setCreated($data['Created']);
 
             foreach ($data['RepoTags'] as $repoTag) {
-                $ret = preg_match('/^(.*):([^:]*)/', $repoTag, $matches);
-                if(1 !== $ret) {
-                    throw new APIException(sprintf('Can not parse repotag %s.', $repoTag));
-                }
-
-                $repository = $matches[1];
-                $tag = $matches[2];
+                list($repository, $tag) = explode(':', $repoTag);
 
                 $tagImage = clone $image;
                 $tagImage->setRepository($repository);

--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -72,11 +72,8 @@ class ImageManager
             $image->setCreated($data['Created']);
 
             foreach ($data['RepoTags'] as $repoTag) {
-                list($repository, $tag) = explode(':', $repoTag);
-
                 $tagImage = clone $image;
-                $tagImage->setRepository($repository);
-                $tagImage->setTag($tag);
+                $tagImage->setRepoTag($repoTag);
 
                 $coll[] = $tagImage;
             }

--- a/src/Docker/Tests/ContainerTest.php
+++ b/src/Docker/Tests/ContainerTest.php
@@ -79,4 +79,22 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         $container->setName('_FooBar');
     }
 
+    public function testConfigImageParsing()
+    {
+        $container = new Container(['Image' => 'postgres:latest']);
+        $image = $container->getImage();
+        $this->assertEquals('postgres', $image->getRepository());
+        $this->assertEquals('latest', $image->getTag());
+
+        $container = new Container(['Image' => 'docker.io/postgres:latest']);
+        $image = $container->getImage();
+        $this->assertEquals('docker.io/postgres', $image->getRepository());
+        $this->assertEquals('latest', $image->getTag());
+
+        $container = new Container(['Image' => 'registry.yourcompany.com:5000/postgres:latest']);
+        $image = $container->getImage();
+        $this->assertEquals('registry.yourcompany.com:5000/postgres', $image->getRepository());
+        $this->assertEquals('latest', $image->getTag());
+
+    }
 }

--- a/src/Docker/Tests/ContainerTest.php
+++ b/src/Docker/Tests/ContainerTest.php
@@ -95,6 +95,12 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         $image = $container->getImage();
         $this->assertEquals('registry.yourcompany.com:5000/postgres', $image->getRepository());
         $this->assertEquals('latest', $image->getTag());
+    }
 
+    public function testInvalidConfigImageParsing()
+    {
+        $container = new Container(['Image' => 'postgres']);
+        $this->setExpectedException('\Docker\Exception\InvalidRepoTagException', 'Invalid repoTag: postgres');
+        $image = $container->getImage();
     }
 }


### PR DESCRIPTION
That PR fixes image name parsing. When using private registries with custom tcp ports, the image name can contain multiple ':', but current code doesn't allow this case. Doing a regexp helps to handle it.

Includes a small unit test.