### PR TITLE
Fix merging ports to allow multiple use of the same port/protocol tuple.

### DIFF
--- a/src/Docker/PortCollection.php
+++ b/src/Docker/PortCollection.php
@@ -40,7 +40,7 @@ class PortCollection implements PortSpecInterface
         $spec = [];
 
         foreach ($this->ports as $port) {
-            $spec = array_merge($spec, $port->toSpec());
+            $spec = array_merge_recursive($spec, $port->toSpec());
         }
 
         return $spec;

--- a/src/Docker/Tests/PortCollectionTest.php
+++ b/src/Docker/Tests/PortCollectionTest.php
@@ -33,4 +33,14 @@ class PortCollectionTest extends PHPUnit_Framework_TestCase
             '22/tcp' => [],
         ], $ports->toExposedPorts());
     }
+
+    public function testToSpecMerge()
+    {
+        $ports = new PortCollection('80', '22', '127.0.0.1:22:22');
+
+        $this->assertEquals([
+            '80/tcp' => [['HostIp' => '', 'HostPort' => '']],
+            '22/tcp' => [['HostIp' => '', 'HostPort' => ''], ['HostIp' => '127.0.0.1', 'HostPort' => '22']],
+        ], $ports->toSpec());
+    }
 }


### PR DESCRIPTION
Unlike ExposedPort, HostConfig["PortBindings"] allows to bind the same port to multiple other ports, as it is an array. As the current use of the array_merge will overwrite existing key when creating spec, it is mandatory to use array_merge_recursive to allow reusing multiple times the same port/protocol tuple.

Includes a unit test to cover the issue.