### PR TITLE
Feature: update logs

### DIFF
--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -3,6 +3,7 @@
 namespace Docker\Manager;
 
 use Docker\Container;
+use Docker\Exception;
 use Docker\Exception\UnexpectedStatusCodeException;
 use Docker\Exception\ContainerNotFoundException;
 use Docker\Http\Stream\InteractiveStream;
@@ -638,10 +639,11 @@ class ContainerManager
      * @param bool $stderr
      * @param bool $timestamp
      * @param string $tail
+     * @param int $since
      *
      * @return array
      */
-    public function logs(Container $container, $follow = false, $stdout = false, $stderr = false, $timestamp = false, $tail = "all")
+    public function logs(Container $container, $follow = false, $stdout = false, $stderr = false, $timestamp = false, $tail = "all", $since = false)
     {
         if (!$stdout && !$stderr) {
             throw new Exception('Bad parameters: you must choose at least one stream', 500);
@@ -661,6 +663,7 @@ class ContainerManager
                 'stderr' => (int)$stderr,
                 'timestamps' => (int)$timestamp,
                 'tail' => $tail,
+                'since' => $since,
             ],
         ]], [
             'callback' => $callback,

--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -643,6 +643,10 @@ class ContainerManager
      */
     public function logs(Container $container, $follow = false, $stdout = false, $stderr = false, $timestamp = false, $tail = "all")
     {
+        if (!$stdout && !$stderr) {
+            throw new Exception('Bad parameters: you must choose at least one stream', 500);
+        }
+
         $logs = [];
 
         $callback = function ($output, $type) use(&$logs) {


### PR DESCRIPTION
- adds the since parameter for docker logs
- performs an additional check which streams are selected and throws an exception if none is selected

Note, if you don't select a stream, you get an empty response, the real error message is available in `response.output` (but maybe not in event request)

Snip from `var_dump($response)`:
```
     ["response.output"]=>
        array(1) {
          [0]=>
          array(1) {
            [0]=>
            object(Closure)#75 (3) {
              ["static"]=>
              array(1) {
                ["callback"]=>
                object(Closure)#79 (3) {
                  ["static"]=>
                  array(1) {
                    ["logs"]=>
                    &array(1) {
                      [0]=>
                      array(2) {
                        ["type"]=>
                        NULL
                        ["output"]=>
                        string(52) "Bad parameters: you must choose at least one stream
"
                      }
                    }
                  }
```

