### PR TITLE
update request excpetion to show message

### DIFF
--- a/src/Docker/Http/Adapter/DockerAdapter.php
+++ b/src/Docker/Http/Adapter/DockerAdapter.php
@@ -74,7 +74,7 @@ class DockerAdapter implements AdapterInterface
             return $transaction->getResponse();
         } catch (RequestException $e) {
             if ($e->hasResponse() && $e->getResponse()->getBody()) {
-                throw new APIException($e->getResponse()->getBody()->__toString(), $e->getRequest(), $e->getResponse(), $e);
+                throw new APIException($e->getMessage(), $e->getRequest(), $e->getResponse(), $e);
             }
 
             throw $e;

--- a/src/Docker/Http/Adapter/DockerAdapter.php
+++ b/src/Docker/Http/Adapter/DockerAdapter.php
@@ -74,7 +74,13 @@ class DockerAdapter implements AdapterInterface
             return $transaction->getResponse();
         } catch (RequestException $e) {
             if ($e->hasResponse() && $e->getResponse()->getBody()) {
-                throw new APIException($e->getMessage(), $e->getRequest(), $e->getResponse(), $e);
+                $message = trim($e->getResponse()->getBody()->__toString());
+
+                if (empty($message)) {
+                    $message = $e->getMessage();
+                }
+
+                throw new APIException($message, $e->getRequest(), $e->getResponse(), $e);
             }
 
             throw $e;


### PR DESCRIPTION
I got several empty error messages, like:

```
Exception 'Docker\Exception\APIException' with message ''
```

With this change you get:

```
Exception 'Docker\Exception\APIException' with message 'Client error response [url] /containers/bcb617efada6/logs?follow=0&stdout=0&stderr=0&timestamps=0&tail=all [status code] 400 [reason phrase] Bad Request'
```