### PR TITLE
[Proposal] docker-compose testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ composer test
 ### Running Tests with `docker-compose`
 
 ```
-$ docker-compose run test
+$ docker-compose run php56
 ```
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Run it using [PHPUnit](http://phpunit.de/):
 $ composer test
 ```
 
+### Running Tests with `docker-compose`
+
+```
+$ docker-compose run test
+```
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -48,8 +48,14 @@ $ composer test
 ### Running Tests with `docker-compose`
 
 ```
+$ docker-compose run php54
+$ docker-compose run php55
 $ docker-compose run php56
+$ docker-compose run php70
 ```
+
+It is recommended to run only one service during testing, since `composer` requirements may depend on the PHP version and
+we are using a host-volume during local testing.
 
 Contributing
 ------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,15 @@
+php54:
+  image: jolicode/php54
+  command: sh -c 'cd /app && composer install && bin/phpunit'
+  volumes:
+    - ./:/app
+    - /var/run/docker.sock:/var/run/docker.sock
+php55:
+  image: jolicode/php55
+  command: sh -c 'cd /app && composer install && bin/phpunit'
+  volumes:
+    - ./:/app
+    - /var/run/docker.sock:/var/run/docker.sock
 php56:
   image: phundament/php-one:5.6-fpm
   command: sh -c 'composer install && bin/phpunit'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
-test:
-  image: phundament/php-one:5.6-fpm-4.6.0-beta1
+php56:
+  image: phundament/php-one:5.6-fpm
+  command: sh -c 'composer install && bin/phpunit'
+  volumes:
+    - ./:/app
+    - /var/run/docker.sock:/var/run/docker.sock
+php70:
+  image: phundament/php-one:7.0-fpm
   command: sh -c 'composer install && bin/phpunit'
   volumes:
     - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+test:
+  image: phundament/php-one:5.6-fpm-4.6.0-beta1
+  command: sh -c 'composer install && bin/phpunit'
+  volumes:
+    - ./:/app
+    - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,24 @@
 php54:
   image: jolicode/php54
-  command: sh -c 'cd /app && composer install && bin/phpunit'
+  command: sh -c 'cd /app && composer update && bin/phpunit'
   volumes:
     - ./:/app
     - /var/run/docker.sock:/var/run/docker.sock
 php55:
   image: jolicode/php55
-  command: sh -c 'cd /app && composer install && bin/phpunit'
+  command: sh -c 'cd /app && composer update && bin/phpunit'
   volumes:
     - ./:/app
     - /var/run/docker.sock:/var/run/docker.sock
 php56:
   image: phundament/php-one:5.6-fpm
-  command: sh -c 'composer install && bin/phpunit'
+  command: sh -c 'composer update && bin/phpunit'
   volumes:
     - ./:/app
     - /var/run/docker.sock:/var/run/docker.sock
 php70:
   image: phundament/php-one:7.0-fpm
-  command: sh -c 'composer install && bin/phpunit'
+  command: sh -c 'composer update && bin/phpunit'
   volumes:
     - ./:/app
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
**Note: This PR is not complete yet, it's primarily a code example atm.**

How about an improved dockerized testing solution? While creating some PRs I also tried to run the tests, but faced some glitches, such as certificate setup and missing images for testing.

The process itself can be improved - for sure. But here's the basic idea: Just run a pre-configured docker container for the tests. 
The image is the [base image](https://github.com/phundament/docker-images/blob/master/phundament/php-one/5.6-7.0/Dockerfile-5.6-fpm) from our PHP app template, but just serves as a PHP cli+composer here - it's also configured to run a PHP app in `/app`.
It would also be possible to run [Codeception](http://codeception.com) tests with this image.

By mounting the `docker.sock` file we can use the docker-client without further configurations.

Feedback appreciated :)