### PR TITLE
Composer update php-http/message version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "jane/open-api": "^1.0",
         "php-http/socket-client": "^1.0",
         "php-http/plugins": "dev-master",
-        "php-http/message": "^0.2@dev",
+        "php-http/message": "^1.0",
         "guzzlehttp/psr7": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Can only install one of: php-http/message[1.0.x-dev, 0.2.0].
    - Can only install one of: php-http/message[v0.2.1, 1.0.x-dev].
    - php-http/plugins dev-master requires php-http/message ^1.0 -> satisfiable by php-http/message[1.0.x-dev].
    - Installation request for php-http/plugins dev-master -> satisfiable by php-http/plugins[dev-master].
    - Installation request for php-http/message ^0.2@dev -> satisfiable by php-http/message[0.2.0, v0.2.1].
```

fix composer dependency for php-http/message